### PR TITLE
Developer book

### DIFF
--- a/developer/behat/context-reference.rst
+++ b/developer/behat/context-reference.rst
@@ -1,0 +1,124 @@
+Context Reference
+=================
+
+Behat matches sentences to methods in ``Context`` classes in order to execute
+things. For example the sentence ``I click on foo`` might map to the method
+``DefaultContext#iClickFoo``.
+
+Context classes can be found in the namespace
+``Sulu\Bundle\<BundleName>\Behat``. Each one contains the logic which applies
+directly to the bundle it belongs to, as such you will probably never need all
+of them.
+
+This chapter will outline the contexts which you will want to use frequently.
+
+AdminContext
+------------
+
+**Bundle**: SuluAdminBundle
+
+This context contains all actions which apply to the backoffice, including all
+actions which apply to *Husky* components.
+
+The following is not a fully comprehensive list:
+
+- ``I expect a success notification to appear``: Wait and assert that a success
+  notification will appear.
+- ``I expect a data grid to appear``: Wait for and assert that a husky
+  datagrid appears
+- ``I expect a form to appear``: Wait for any ``<form/>`` to appear on the
+  page.
+- ``I expect an overlay to appear``: Wait and assert that an overlay appears
+  on the page.
+- ``I click the tick button``: Click the tick button in a dialog
+- ``I confirm``: Confirm a dialog
+- ``I click the search icon``: Click the search icon (``.btn .fa-search``)
+- ``I click the row containing ":text"``: Click on the husky table row
+  containing "text".
+- ``I select :value from the husky :name``: Select the given value from
+  a husky drop-down selector as identified by selector.
+- ``I fill in husky field ":name" with ":value"``: Fill in a husky field (husky
+  fields do not have ``name`` elements preventing us from using the default
+  mechanisim).
+- ``I click the button ":text"``: Click the button containing the text ``:text``
+- ``I expect the ":event" event``: Wait for the named aura event
+- ``I expect the following events``: Wait until all of the given events have
+  been emitted.
+- ``There should be errors``: Assert that there are errors on the page.
+- ``I wait for the ajax request``: Wait until all underlying AJAX requests
+  have finished.
+
+ContentContext
+--------------
+
+**Bundle**: SuluContentBundle
+
+You will use the content context frequently when testing content types.
+
+- ``there exists a page template ":name" with the following property
+  configuration``: Create a page template with a given content type
+  configuration:
+
+.. code-block:: cucumber
+
+    Background:
+        Given there exists a page template "checkbox_page" with the following property configuration
+        """
+        <property name="checkbox" type="checkbox">
+            <meta>
+                <title lang="de">Checkbox</title>
+            </meta>
+        </property>
+        """
+
+- ``the following pages exist``: Create pages from the given data, for
+  example:
+
+.. code-block:: cucumber
+
+        And the following pages exist:
+            | template | url | title | parent | data |
+            | article | /articles | Articles | | {"body": "This is article 1"} |
+            | article | /articles/foo | Foo | /articles | {"body": "This is article Foo"} |
+
+- ``I am editing page of type :type``: Create a simple page with the given
+  type and go to that page:
+
+.. code-block:: cucumber
+
+        Given I am editing a page of type "color_page"
+
+- ``I expect aura component ":type" to appear``: Wait for the aura component
+  to appear. Waits for a ``<div/>`` with the ``aura-instance-name`` property
+  equal to the given name to appear **and** have more than zero children.
+
+SecurityContext
+---------------
+
+**Bundle**: SuluSecurityBundle
+
+- ``Given I am logged in as an administrator``: Login to Sulu using
+  ``admin/admin``.
+
+DefaultContext
+--------------
+
+**Bundle**: SuluTestBundle
+
+The Default context is the most used context and provides lots of "primitive"
+actions.
+
+- ``I click the selector ":selector"``: Click the element identified by the
+  given CSS selector (will wait until it appears).
+- ``I click on "":selector" in ":container"``: Click the element identified by the
+  given CSS selector container within a container CSS selector. (will wait until it appears).
+- ``pause``: Pause the test forever -- for debugging.
+- ``wait a second``: Wait 1 second. If you use this you are a bad person.
+- ``I expect to see ":text"``. Wait until text appears and then assert that it
+  did.
+- ``I expect to see ":count" ":text" elements``. Wait until text appears and
+  then assert that there are a specified number of them.
+- ``I fill in the selector :selector with :value``: Set the value on elements
+  identified by the given CSS selector.
+- ``Press enter on ":selector"``: Simulate an "enter" key being pressed on the
+  given CSS selector.

--- a/developer/behat/getting-started.rst
+++ b/developer/behat/getting-started.rst
@@ -1,0 +1,114 @@
+Getting started
+===============
+
+Choosing Driver
+---------------
+
+Selenium2 (with a browser)
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+It is recommended to run tests locally with the `Selenium`_ driver. Using the
+Selenium driver on a real browser allows you to see the tests running (as
+opposed to using a headless browser as detailed in the following sections).
+
+You can `download Selenium server from here`_, or install it as follows:
+
+.. code-block:: bash
+
+    $ mkdir ~/jars
+    $ cd jars
+    $ wget http://selenium-release.storage.googleapis.com/2.44/selenium-server-standalone-2.44.0.jar
+
+You can then run it:
+
+.. code-block:: bash
+
+    $ java -jar selenium-server-standalone-2.44.0.jar -browserSessionReuse -singleWindow
+
+The ``-browserSessionReuse`` tells selenium NOT to close the window after
+every test and ``-singleWindow`` will cause Selenium not to use more than one
+window.
+
+.. note::
+
+    You will need to install the Java Runtime Environment. On a debian based
+    system you could do ``apt-get install default-jre``
+
+Selenium2 (headless, with PhantomJs)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. note::
+
+    It is not currently recommended to run tests on PhantomJS - the results
+    may be unpredictable.
+
+PhantomJS can be installed with ``npm``:
+
+.. code-block:: bash
+
+    $ npm install phantomjs
+
+You can then run it as follows:
+
+.. code-block:: bash
+
+    $ phantomjs --webdriver=8643
+
+Then you will need to copy the default ``behat.yml.dist`` to ``behat.yml`` and
+add the ``wd_host`` option as follows:
+
+.. code-block:: yaml
+
+    defaults:
+        # ...
+        extensions:
+            # ...
+            Behat\MinkExtension:
+                sessions:
+                    default:
+                        selenium2:
+                            wd_host: "http://localhost:8643/wd/hub"
+
+Sauce Labs
+~~~~~~~~~~
+
+Our continuous integration system will run the tests on the Sauce Labs
+service. See :doc:`sauce-labs` to find out how to run them yourself or for
+more information.
+
+Running the tests
+-----------------
+
+You can run all the tests as follows:
+
+.. code-block:: bash
+
+    $ ./vendor/behat/behat/bin/behat -p<profile>
+
+Where ``<profile>`` is one of:
+
+- **selenium**: Tests on your local machine via Selenium using a real browser
+  above)
+- **sauce_labs**: Run the tests on Sauce Labs (see :doc:`sauce-labs`).
+
+The tests are split up into a number of *suites*. There is one suite for each
+bundle, named after the bundle in lowercase, for example ``SuluContactBundle``
+has the suite named ``contact``.
+
+Run specific suites as follows:
+
+.. code-block:: bash
+
+    $ ./vendor/behat/behat/bin/behat --suite=contact
+
+Further more you can filter for specific tests using the ``name`` option:
+
+.. code-block:: bash
+
+    $ ./vendor/behat/behat/bin/behat --suite=contact --name="Create"
+
+The above will run all scenarios in the ``contact`` suite which contain the word
+``Create``.
+
+.. _Selenium: htto://www.seleniumhq.org
+.. _download selenium server from here: http://www.seleniumhq.org/download/

--- a/developer/behat/index.rst
+++ b/developer/behat/index.rst
@@ -1,0 +1,9 @@
+Behat (Functional) Testing
+==========================
+
+.. toctree::
+    :maxdepth: 2
+
+    getting-started
+    context-reference
+    sauce-labs

--- a/developer/behat/sauce-labs.rst
+++ b/developer/behat/sauce-labs.rst
@@ -1,0 +1,84 @@
+Sauce Labs
+==========
+
+`Sauce Labs`_ is a service which allows you to run browser tests
+remotely. Like `Travis CI`_ it is free for open source projects such
+as SuluCMF.
+
+It functions in a similar way to the :doc:`getting-started` tests which you run
+locally, but instead of connecting to a local Selenium server you
+connect to the `Sauce Labs`_ server.
+
+It works briefly as follows, you:
+
+- Running your local web server
+- You download and run the Sauce Labs connection tunnel
+- You run your tests
+- Your test runner talks to the Sauce Labs server
+- The Sauce Labs server connects to *your* webserver through the tunnel
+- The tests are rendered in the browser on the Sauce Labs server
+- You watch the tests in real-time on the Sauce Labs web page.
+
+Prerequisites
+-------------
+
+- You will need a `username` and `access-key` on Sauce Labs before continuing.
+  `Sign-up here`_!
+
+Downloading and Running the Connect Daemon
+------------------------------------------
+
+To run the tests remotely you will need to install and run the connect daemon.
+This application will establish an SSH tunnel to the saucelabs server through
+which HTTP requests will be sent to your webserver.
+
+Download and unpack the ``Sauce-Connect`` file, for example:
+
+.. code-block:: bash
+
+    $ cd ~
+    $ mkdir jars
+    $ cd jars
+    $ curl http://saucelabs.com/downloads/Sauce-Connect-latest.zip > SauceConnect.zip
+    $ unzip SauceConnect.zip
+
+Run it, replacing ``<username>`` and ``<access-key>`` with your credentials:
+
+.. code-block:: bash
+
+    $ java -jar Sauce-Connect.jar <username> <access-key>
+
+Wait for the message:
+
+.. code-block:: bash
+
+    Connected! You may start your tests
+
+Running the tests
+-----------------
+
+Great! Everything is almost ready, but now you need to set a couple of
+environment variables before we run the tests.
+
+.. code-block:: bash
+
+    $ export SAUCE_USERNAME=<username>
+    $ export SAUCE_ACCESS_KEY=<access-key>
+
+Now you can finally launch behat using the ``sauce_labs`` profile:
+
+.. code-block:: bash
+
+    $ ./vendor/behat/behat/bin/behat -p sauce_labs
+
+Visit https://saucelabs.com/tests to view the results.
+
+.. note::
+
+    You can easily specify only a specific or a subset of tests to run, see
+    the :doc:`getting-started` guide.
+
+.. _Sauce Labs: https://saucelabs.com/account
+.. _tunnel: https://en.wikipedia.org/wiki/Tunneling_protocol
+.. _Travis CI: http://travis-ci.org
+.. _Sign-up here: https://saucelabs.com/signup/trial

--- a/developer/index.rst
+++ b/developer/index.rst
@@ -1,0 +1,7 @@
+Developer Guide
+===============
+
+.. toctree::
+    :maxdepth: 2
+
+    behat/index

--- a/index.rst
+++ b/index.rst
@@ -6,3 +6,4 @@ Welcome to Sulu 2.0's documentation!
 
     book/index
     reference/index
+    developer/index.rst


### PR DESCRIPTION
I think we should add a developer guide here. This would be a separate book, so there would be the User section (which I believe is what this currently is) and the Developer section.

We need this because developer documentation should be a first-class citizen and the quality of such a document should be important otherwise it will not be used.

For example I want to write a guide on how to write behat tests, standardize UI workflows (e.g. there should always be a success / error notification, delete buttons should always be here, etc.).

Doing this in markdown in the existing `/docs` repository which is of variable quality does not really appeal to me and browsing such documents on GITHub isn't the best experience - RST provides a much richer medium for technical documentation and readthedocs provides a great reading experience.